### PR TITLE
feat: solo service area support

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
   "greeting": "",
   "analyticsHeader": "",
-  "analyticsFooter": ""
+  "analyticsFooter": "",
+
+  "hiddenServiceAreas": ["sv"]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,14 @@ export default {
       if (territory) {
         return Response.redirect(new URL(`/${territory.path}`, request.url).toString(), 302);
       }
+
+
+      // if there's only one territory being able to be shown, redirect to that territory
+      const oneTerritory = territoryPromo.filter((t) => !config.hiddenServiceAreas.includes(t.path)).length === 1;
+      if (oneTerritory) {
+          return Response.redirect(new URL(`/${territoryPromo[0].path}`, request.url).toString(), 302);
+      }
+
       return Response.redirect(new URL("/choose", request.url).toString(), 302);
     }
 
@@ -268,6 +276,8 @@ export default {
 
 // 🎨 Generates the promo page HTML
 function generatePromoHTML(title: string, promoCode: string, activated: boolean, url: string): string {
+  const onlyOneTerritory = territoryPromo.filter((t) => !config.hiddenServiceAreas.includes(t.path)).length === 1;
+
   return `<!DOCTYPE html>
   <html lang="en">
   <head>
@@ -289,7 +299,7 @@ function generatePromoHTML(title: string, promoCode: string, activated: boolean,
         <h3>${greeting}</h3>
         <h1>$10 off your first<br/>Waymo One ride</h1>
         <h3 style="margin-top: 10px">${title}</h3>
-        <p style="margin-top: 0">Wrong service area? <a class="back-link" href="/choose" style="text-decoration: none;">Choose another →</a></p>
+        ${!onlyOneTerritory && `<p style="margin-top: 0">Wrong service area? <a class="back-link" href="/choose" style="text-decoration: none;">Choose another →</a></p>`}
         ${!activated ? 
           `<p class="error-text">Code has been used up this month.\nTry again next month.</p>` 
         : 

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,13 @@ export default {
       if (territory) {
         return Response.redirect(new URL(`/${territory.path}`, request.url).toString(), 302);
       }
+
+      // if there's only one territory being able to be shown, redirect to that territory
+      const oneTerritory = territoryPromo.filter((t) => !config.hiddenServiceAreas.includes(t.path)).length === 1;
+      if (oneTerritory) {
+        return Response.redirect(new URL(`/${territoryPromo[0].path}`, request.url).toString(), 302);
+      }
+
       return Response.redirect(new URL("/choose", request.url).toString(), 302);
     }
 
@@ -233,7 +240,7 @@ export default {
      *   - promo_[sa]-activated: "true"
      */
 
-    // 🔑 Check if promo code exists in KV
+        // 🔑 Check if promo code exists in KV
     const promoCodeExists = await env.PROMO_KV.get(promoKey) !== null;
     const promoCodeActivated = await env.PROMO_KV.get(`${promoKey}-activated`) !== null;
 
@@ -268,6 +275,7 @@ export default {
 
 // 🎨 Generates the promo page HTML
 function generatePromoHTML(title: string, promoCode: string, activated: boolean, url: string): string {
+  const onlyOneTerritory = territoryPromo.filter((t) => !config.hiddenServiceAreas.includes(t.path)).length === 1;
   return `<!DOCTYPE html>
   <html lang="en">
   <head>
@@ -283,12 +291,12 @@ function generatePromoHTML(title: string, promoCode: string, activated: boolean,
         <h3>${greeting}</h3>
         <h1>$10 off your first<br/>Waymo One ride</h1>
         <h3 style="margin-top: 10px">${title}</h3>
-        <p style="margin-top: 0">Wrong service area? <a class="back-link" href="/choose" style="text-decoration: none;">Choose another →</a></p>
-        ${!activated ? 
-          `<p class="error-text">Code has been used up this month.\nTry again next month.</p>` 
-        : 
-          "<p id=\"copiedText\">Code copied!</p>"
-        }
+        ${!onlyOneTerritory && `<p style="margin-top: 0">Wrong service area? <a class="back-link" href="/choose" style="text-decoration: none;">Choose another →</a></p>`}
+        ${!activated ?
+      `<p class="error-text">Code has been used up this month.\nTry again next month.</p>`
+      :
+      "<p id=\"copiedText\">Code copied!</p>"
+  }
         <div id="codeBox" class="code-box ${!activated ? "error" : ""}">
           <input type="text" id="promoCode" value="${promoCode}" readonly
             style="border: none; background: none; width: 100%; font-size: 1.5rem;">
@@ -320,14 +328,12 @@ function generatePromoHTML(title: string, promoCode: string, activated: boolean,
 
 // 📍 Generates the choose location page
 function generateChooseHTML()  {
-
-
-    const territoryPromoString = territoryPromo.map((t) => {
-          // config.hiddenServiceAreas is an array of strings with the names of the service areas to hide, by territoryPromo.path
+  const territoryPromoString = territoryPromo.map((t) => {
+        // config.hiddenServiceAreas is an array of strings with the names of the service areas to hide, by territoryPromo.path
         // check if the territory is hidden, if so, skip it
         if (!config.hiddenServiceAreas.includes(t.path)) return `<a href="/${t.path}" class="big-button">${t.name}</a>`;
-    }
-    ).join("");
+      }
+  ).join("");
 
   return `<!DOCTYPE html>
   <html lang="en">

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,9 @@ export default {
 
     // 🎯 Determine territory and promo code
     const territory = territoryPromo.find((t) => url.pathname.startsWith(`/${t.path}`));
+
+
+
     if (territory) {
       // 🎯 Territory page
       promoKey = territory.promo;
@@ -217,10 +220,17 @@ export default {
       });
     }
 
+    // is territory hidden?
+    if (config.hiddenServiceAreas.includes(territory?.path)) {
+      return new Response(generateChooseHTML(), {
+        headers: { "Content-Type": "text/html" },
+      });
+    }
+
     /**
      * 2. Add the following key-value pairs:
-     *   - promo_la: "https://waymo.com/la?code=LA-XXXX"
-     *   - promo_la-activated: "false"
+     *   - promo_[sa]: "https://waymo.smart.link/4pcoqniy5?code=CHANGE_KV"
+     *   - promo_[sa]-activated: "true"
      */
 
     // 🔑 Check if promo code exists in KV
@@ -311,8 +321,11 @@ function generatePromoHTML(title: string, promoCode: string, activated: boolean,
 // 📍 Generates the choose location page
 function generateChooseHTML()  {
 
+
     const territoryPromoString = territoryPromo.map((t) => {
-        return `<a href="/${t.path}" class="big-button">${t.name}</a>`;
+          // config.hiddenServiceAreas is an array of strings with the names of the service areas to hide, by territoryPromo.path
+        // check if the territory is hidden, if so, skip it
+        if (!config.hiddenServiceAreas.includes(t.path)) return `<a href="/${t.path}" class="big-button">${t.name}</a>`;
     }
     ).join("");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,6 +273,12 @@ function generatePromoHTML(title: string, promoCode: string, activated: boolean,
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
+    <meta property="og:description" content="$10 off your first Waymo One ride!" />
+    <meta property="og:image" content="https://waymo.com/img/waymo-half-shot.png" />
+    <meta property="og:type" content="website" />
+    
+    
     <title>${title}</title>
     ${styles}
     ${analyticsHeader}
@@ -320,8 +326,6 @@ function generatePromoHTML(title: string, promoCode: string, activated: boolean,
 
 // 📍 Generates the choose location page
 function generateChooseHTML()  {
-
-
     const territoryPromoString = territoryPromo.map((t) => {
           // config.hiddenServiceAreas is an array of strings with the names of the service areas to hide, by territoryPromo.path
         // check if the territory is hidden, if so, skip it
@@ -335,8 +339,15 @@ function generateChooseHTML()  {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Choose Your Service Area</title>
+    
+    <meta property="og:description" content="$10 off your first Waymo One ride!" />
+    <meta property="og:image" content="https://waymo.com/img/waymo-half-shot.png" />
+    <meta property="og:type" content="website" />
+    
     ${styles}
     ${analyticsHeader}
+    
+    
   </head>
   <body>
     ${credit}


### PR DESCRIPTION
This pull request introduces a feature to handle cases where only one territory is available for selection, improving user experience by automatically redirecting or adjusting the UI accordingly. The changes include logic updates for redirection, conditional rendering in the promo page, and minor cleanups.

### Redirection logic updates:

* Added a check in `src/index.ts` to detect if only one visible territory exists (`oneTerritory`). If true, the user is redirected directly to that territory instead of the generic "choose" page.

### Promo page adjustments:

* Updated the `generatePromoHTML` function to include a similar check (`onlyOneTerritory`) and conditionally hide the "Choose another" link when only one territory is available. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R278) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L286-R294)

### Minor cleanup:

* Removed unnecessary blank lines in the `generateChooseHTML` function for better readability.